### PR TITLE
Change Github runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   release-localstack-openapi:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       release: ${{ github.event_name == 'workflow_dispatch' && inputs.releaseVersion || github.event.client_payload.releaseVersion}}
 


### PR DESCRIPTION
In https://github.com/localstack/openapi/pull/7 we introduced a workflow to release OpenAPI specs.
We used `buildjet-2vcpu-ubuntu-2204` as a GitHub runner, but this is not available in this repo.
With this PR we switch to the default `ubuntu-latest`.