### PR TITLE
Preserve multiline strings

### DIFF
--- a/bin/update-aws-spec.py
+++ b/bin/update-aws-spec.py
@@ -8,6 +8,20 @@ from localstack.version import version as ls_version
 
 import click
 
+
+def str_presenter(dumper, data):
+    """
+    Reading multiline yaml strings (with the `|` indicator) results in newlines added when dumping the YAML.
+    This function helps to preserve the original multiline formatting.
+    """
+    if '\n' in data:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+yaml.add_representer(str, str_presenter)
+
+
 @click.command()
 @click.option('--latest', is_flag=True, default=False, help='If enabled, sets the version of the spec to latest.')
 def update_aws_spec(latest: bool) -> None:


### PR DESCRIPTION
Loading and then dumping a spec with multiline strings with the `|` indicator results in a bunch of `\n`, instead of preserving the original multiline formatting (see [here](https://github.com/localstack/openapi/blob/ea09503f89e86fc2b82b2f891b630e15548fd5ed/openapi/emulators/localstack-spec-latest.yml#L928-L934) for example).

This PR makes sure the formatting is correctly preserved.