### PR TITLE
explicitly set tag on draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           name: v${{ env.release }}
           files: |
             openapi/emulators/localstack-spec.yml
+          tag_name: v${{ env.release }}
           draft: true
 
       - name: "Show git modifications"


### PR DESCRIPTION
## Motivation
With the release of 4.2.0, a draft release was [automatically created by the `release` workflow](https://github.com/localstack/openapi/actions/runs/13561945791).
While it does create a tag, and does create a draft release, it does not set the tag on the draft release.
This works for other usages of the `softprops/action-gh-release` action, because usually these pipelines are not triggered by a `repository_dispatch` event, but by the tag push (and the default is `github.ref_name`).

## Changes
- Explicitly set the tag for the draft release in the release action