### PR TITLE
Fix openapi spec update workflow

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-to-latest:
     name: "Update specs to latest"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq postgresql-14=14.13-0ubuntu0* postgresql-client postgresql-plpython3 libvirt-dev
+          sudo apt-get install -y --allow-downgrades libsnappy-dev jq libvirt-dev
 
       - name: Checkout Community
         uses: actions/checkout@v4

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-to-latest:
     name: "Update specs to latest"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation
Recently, the update workflow for the openapi spec started failing: https://github.com/localstack/openapi/actions/runs/12580552752
This was caused by the update of the `ubuntu-latest` runner to 24.04 (see actions/runner-images#10636).

The new image only has postgres16, not postgres14 anymore.

I pinned the image to 24.04 (to avoid future uncontrolled regressions) and removed the postgres installer similar to localstack/localstack#11974 - as it should not be necessary.

## Changes
* pin update spec workflow to ubuntu-24.04 runner
* remove postgres installation
