### PR TITLE
Add workflow to trigger the SDK release

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,23 @@
+name: Release SDKs
+
+on:
+  release:
+    # Start the release of the SDKs when a new GitHub release of the OpenAPI spec is _published_
+    types: [published]
+
+jobs:
+  release-python-sdk:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: "Compute version"
+        run: |
+            TAG=${{ github.event.release.tag_name }}
+            echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+      - name: "Release Python SDK"
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PRO_GITHUB_TOKEN }}
+          repository: localstack/localstack-sdk-python
+          event-type: release-sdk
+          client-payload: '{"version": "${{ env.VERSION }}"}'


### PR DESCRIPTION
We recently introduced a [workflow](https://github.com/localstack/localstack-sdk-python/pull/16) to release a Python SDK version from a released OpenAPI spec. We can manually trigger this workflow, but ideally, we want to be part of the release automation.

This PR introduces a workflow triggered upon publishing a new OpenAPI release (already part of the release process).
This workflow does nothing more than i) computing the version from the tag, and ii) triggering the Python SDK workflow.