### PR TITLE
refactor workflows after restructuring

### DIFF
--- a/.github/actions/generate-spec/action.yml
+++ b/.github/actions/generate-spec/action.yml
@@ -1,0 +1,60 @@
+name: Generate OpenAPI spec
+description: Checks out localstack-pro, installs dependencies, and runs update-aws-spec.py.
+
+inputs:
+  pro-ref:
+    description: Ref to check out in localstack-pro. Leave empty to use the default branch.
+    required: false
+    default: ""
+  pro-token:
+    description: Token used to check out localstack-pro.
+    required: true
+  fallback-to-main:
+    description: If "true", fall back to the default branch when the specified ref cannot be checked out.
+    required: false
+    default: "false"
+  latest:
+    description: If "true", pass --latest to update-aws-spec.py.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install OS packages
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --allow-downgrades libvirt-dev
+
+    - name: Checkout Pro
+      id: pro-checkout
+      uses: actions/checkout@v4
+      continue-on-error: ${{ inputs.fallback-to-main == 'true' }}
+      with:
+        repository: localstack/localstack-pro
+        path: localstack-pro
+        token: ${{ inputs.pro-token }}
+        ref: ${{ inputs.pro-ref }}
+
+    - name: Pro - fallback to default branch
+      if: ${{ inputs.fallback-to-main == 'true' && steps.pro-checkout.outcome == 'failure' }}
+      uses: actions/checkout@v4
+      with:
+        repository: localstack/localstack-pro
+        path: localstack-pro
+        token: ${{ inputs.pro-token }}
+
+    - name: Install Python dependencies for Pro
+      working-directory: localstack-pro/localstack-pro-aws/
+      shell: bash
+      run: make install
+
+    - name: Generate spec
+      shell: bash
+      run: |
+        source localstack-pro/localstack-pro-aws/.venv/bin/activate
+        python bin/update-aws-spec.py ${{ inputs.latest == 'true' && '--latest' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,42 +24,22 @@ jobs:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install OS packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libvirt-dev
-
-      - name: Checkout Pro
-        uses: actions/checkout@v4
-        id: pro-checkout
+      - name: Generate spec
+        uses: ./.github/actions/generate-spec
         with:
-          repository: localstack/localstack-pro
-          path: localstack-pro
-          token: ${{ secrets.PRO_GITHUB_TOKEN }}
-          ref: v${{ env.release }}
-
-      - name: Install OS packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libvirt-dev
-
-      - name: Install Python Dependencies for Pro
-        working-directory: localstack-pro/localstack-pro-aws/
-        run: make install
- 
-      - name: Generate the latest spec
-        run: |
-          source localstack-pro/localstack-pro-aws/.venv/bin/activate
-          python bin/update-aws-spec.py
+          pro-ref: v${{ env.release }}
+          pro-token: ${{ secrets.PRO_GITHUB_TOKEN }}
 
       - name: "Commit release version"
         # We set the openapi folder as a DEPENDENCY_FILE merely to have it added to the release commit
         run: |
           DEPENDENCY_FILE="openapi/" bin/release-helper.sh git-commit-release ${{ env.release }}
           git push --follow-tags
+
+      - name: "Show git modifications"
+        run: |
+          git log --oneline -n 2
+          git show HEAD
 
       - name: Release
         uses: softprops/action-gh-release@v2
@@ -69,8 +49,3 @@ jobs:
             openapi/emulators/localstack-spec.yml
           tag_name: v${{ env.release }}
           draft: true
-
-      - name: "Show git modifications"
-        run: |
-          git log --oneline -n 2
-          git show HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release OpenAPI spec
 on:
   repository_dispatch:
-    types: [release-openapi]
   workflow_dispatch:
     inputs:
       releaseVersion:
@@ -10,8 +9,10 @@ on:
         description: The version to be released
 
 env:
-  git_user_name: localstack[bot]
-  git_user_email: localstack-bot@users.noreply.github.com
+  GIT_AUTHOR_NAME: localstack[bot]
+  GIT_AUTHOR_EMAIL: localstack-bot@users.noreply.github.com
+  GIT_COMMITTER_NAME: localstack[bot]
+  GIT_COMMITTER_EMAIL: localstack-bot@users.noreply.github.com
 
 jobs:
   release-localstack-openapi:
@@ -20,55 +21,38 @@ jobs:
       release: ${{ github.event_name == 'workflow_dispatch' && inputs.releaseVersion || github.event.client_payload.releaseVersion}}
 
     steps:
-      - name: "Checkout OpenAPI repo"
+      - name: Checkout OpenAPI
         uses: actions/checkout@v4
 
-      - name: "Install release helper"
-        env:
-          GITHUB_TOKEN: ${{ secrets.PRO_GITHUB_TOKEN }}
-        run: |
-          mkdir -p bin
-          curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github.v3.raw" \
-            "https://api.github.com/repos/localstack/localstack-core/contents/bin/release-helper.sh" \
-            -o bin/release-helper.sh
-          chmod +x bin/release-helper.sh
-
-      - name: "Prepare git config"
-        run: |
-          git config user.name ${{ env.git_user_name }}
-          git config user.email ${{ env.git_user_email }}
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-
-      - name: "Wait for localstack, localstack-core, and localstack-ext release to appear"
-        timeout-minutes: 3
-        run: |
-          bin/release-helper.sh pip-download-retry localstack ${{ env.release }}
-          bin/release-helper.sh pip-download-retry localstack-core ${{ env.release }}
-          bin/release-helper.sh pip-download-retry localstack-ext ${{ env.release }}
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq libvirt-dev
+          sudo apt-get install -y --allow-downgrades libvirt-dev
 
-      - name: "Install LocalStack and LocalStack-ext"
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install localstack-ext==${{ env.release }}
+      - name: Checkout Pro
+        uses: actions/checkout@v4
+        id: pro-checkout
+        with:
+          repository: localstack/localstack-pro
+          path: localstack-pro
+          token: ${{ secrets.PRO_GITHUB_TOKEN }}
+          ref: v${{ env.release }}
 
-      - name: "Create tagged LocalStack OpenAPI spec"
+      - name: Install OS packages
         run: |
-          source .venv/bin/activate
-          pip install click
-          pip install pyyaml
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades libvirt-dev
+
+      - name: Install Python Dependencies for Pro
+        working-directory: localstack-pro/localstack-pro-aws/
+        run: make install
+ 
+      - name: Generate the latest spec
+        run: |
+          source localstack-pro/localstack-pro-aws/.venv/bin/activate
           python bin/update-aws-spec.py
 
       - name: "Commit release version"

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -1,5 +1,5 @@
 name: Update OpenAPI specs to latest
-on: 
+on:
   repository_dispatch:
     types: [openapi-update]
   workflow_dispatch:
@@ -12,41 +12,14 @@ jobs:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install OS packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libvirt-dev
-
-      - name: Checkout Pro
-        uses: actions/checkout@v4
-        id: pro-checkout
-        continue-on-error: true
+      - name: Generate spec
+        uses: ./.github/actions/generate-spec
         with:
-          repository: localstack/localstack-pro
-          path: localstack-pro
-          token: ${{ secrets.PRO_GITHUB_TOKEN }}
-          ref: ${{ github.event.client_payload.ref }}
-          
-      - name: Pro - fallback to main branch
-        if: steps.pro-checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          repository: localstack/localstack-pro
-          path: localstack-pro
-          token: ${{ secrets.PRO_GITHUB_TOKEN }}
+          pro-ref: ${{ github.event.client_payload.ref }}
+          pro-token: ${{ secrets.PRO_GITHUB_TOKEN }}
+          fallback-to-main: "true"
+          latest: "true"
 
-      - name: Install Python Dependencies for Pro
-        working-directory: localstack-pro/localstack-pro-aws/
-        run: make install
- 
-      - name: Generate the latest spec
-        run: |
-          source localstack-pro/localstack-pro-aws/.venv/bin/activate
-          python bin/update-aws-spec.py --latest
-      
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -12,35 +12,13 @@ jobs:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4
 
-      - name: "Set up Python 3.13"
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
 
       - name: Install OS packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libsnappy-dev jq libvirt-dev
-
-      - name: Checkout Community
-        uses: actions/checkout@v4
-        id: community-checkout
-        continue-on-error: true
-        with:
-          repository: localstack/localstack
-          path: localstack
-          ref: ${{ github.event.client_payload.ref }}
-  
-      - name: Community - fallback to main branch
-        if: steps.community-checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          repository: localstack/localstack
-          path: localstack
+          sudo apt-get install -y --allow-downgrades libvirt-dev
 
       - name: Checkout Pro
         uses: actions/checkout@v4
@@ -61,12 +39,12 @@ jobs:
           token: ${{ secrets.PRO_GITHUB_TOKEN }}
 
       - name: Install Python Dependencies for Pro
-        working-directory: localstack-pro
+        working-directory: localstack-pro/localstack-pro-aws/
         run: make install
  
       - name: Generate the latest spec
         run: |
-          source localstack-pro/localstack-pro-core/.venv/bin/activate
+          source localstack-pro/localstack-pro-aws/.venv/bin/activate
           python bin/update-aws-spec.py --latest
       
       - name: Create PR


### PR DESCRIPTION
## Motivation
We just recently performed on a restructuring of our repositories. We now have our specs in a single repository.
This PR updates our workflows such that they use the new structure. Along the way I also extracted some of the code into a shared action.

## Changes
- Update the checkout and the assumed project structure.
- Change the release workflow such that it does not rely on PyPi packages being published (which we stopped just recently).
- Extract the core logic of checking out the repo and updating the specs to a reusable composite action.