### PR TITLE
CI: Update OpenAPI Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,19 +24,23 @@ jobs:
       - name: Checkout OpenAPI
         uses: actions/checkout@v4
 
-      - name: Generate spec
+      - name: Generate Spec
         uses: ./.github/actions/generate-spec
         with:
           pro-ref: v${{ env.release }}
           pro-token: ${{ secrets.PRO_GITHUB_TOKEN }}
 
-      - name: "Commit release version"
-        # We set the openapi folder as a DEPENDENCY_FILE merely to have it added to the release commit
+      - name: Commit Release Version
+        env:
+          DEPENDENCY_FILE: "openapi/"
+          RELEASE_VERSION: ${{ env.release }}
         run: |
-          DEPENDENCY_FILE="openapi/" bin/release-helper.sh git-commit-release ${{ env.release }}
-          git push --follow-tags
+          git add "${DEPENDENCY_FILE}"
+          git commit --allow-empty -m "Release: v${RELEASE_VERSION}"
+          git tag -a "v${RELEASE_VERSION}" -m "Release: v${RELEASE_VERSION}"
+          git push --follow-tags  
 
-      - name: "Show git modifications"
+      - name: Show Git Modifications
         run: |
           git log --oneline -n 2
           git show HEAD


### PR DESCRIPTION
## Changes + Motivation
- During the release I noticed the release notes weren't being created for this repo and for `localstack-python-sdk` due to this run here https://github.com/localstack/openapi/actions/runs/25095911665
- We no longer use the release helper here to push a tagged commit so I updated the workflow to no longer reference it. 
- This is blocking for publishing the release notes for this repository and for `localstack-python-sdk`.
- Opted to remove the dependency entirely instead of re-adding as it's only used for simple git operations.